### PR TITLE
Fix all outstanding issues

### DIFF
--- a/lib/src/features/auth/data/models/user_model.dart
+++ b/lib/src/features/auth/data/models/user_model.dart
@@ -20,10 +20,10 @@ class UserModel {
     this.firstName,
     this.lastName,
     this.email,
-    this.roles = const [],
+    List<UserRole>? roles,
     this.createdAt,
     this.updatedAt,
-  });
+  }) : roles = roles ?? const [];
 
   factory UserModel.fromJson(Map<String, dynamic> json) => _$UserModelFromJson(json);
 


### PR DESCRIPTION
Update `UserModel` constructor to initialize `roles` via an initializer list to resolve a generator warning conflicting with `@JsonKey(defaultValue: [])`.

---
<a href="https://cursor.com/background-agent?bcId=bc-5394ff86-ac89-4dd1-aefa-22261fa7edcb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5394ff86-ac89-4dd1-aefa-22261fa7edcb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

